### PR TITLE
Pull ir_proximity prop out of common repo (1/3)

### DIFF
--- a/msm8974.mk
+++ b/msm8974.mk
@@ -234,9 +234,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.extension_library=libqti-perfd-client.so \
     ro.telephony.call_ring.multiple=0
 
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.qti.sensors.ir_proximity=true
-
 # Permissions
 PRODUCT_COPY_FILES += \
     external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml:system/etc/permissions/com.dsi.ant.antradio_library.xml \


### PR DESCRIPTION
The N3's firmware really doesn't like this.

Change-Id: I2db7138a58b2c6d535db99b69bb0c8159c5aaadc